### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,6 +9,8 @@ on:
   workflow_dispatch:
 
 name: ci-build
+permissions:
+  contents: read
 
 jobs:
 


### PR DESCRIPTION
Potential fix for [https://github.com/OpenShock/Common.Net/security/code-scanning/3](https://github.com/OpenShock/Common.Net/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow. Based on the provided steps, the workflow primarily reads repository contents and does not appear to require write access. Therefore, the `permissions` block should specify `contents: read`. If additional permissions are needed in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
