### PR TITLE
security: Pin Github Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,23 +19,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.4.2
+        uses: gittools/actions/gitversion/setup@bc6623af8fc07d5a8903052dd46da33403eec8e8  # v4.5.0
         with:
           versionSpec: '6.3.x'
           
       - name: Determine Version
         id: version_step
-        uses: gittools/actions/gitversion/execute@v4.4.2
+        uses: gittools/actions/gitversion/execute@bc6623af8fc07d5a8903052dd46da33403eec8e8  # v4.5.0
         with:
           updateProjectFiles: true
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: '9.0.x'
       

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,17 +27,17 @@ jobs:
       contents: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
       with:
         languages: csharp
         build-mode: manual
     
     - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -49,6 +49,6 @@ jobs:
         dotnet publish DynamicLinq/DynamicLinq.csproj -c Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
       with:
         category: "/language:csharp"

--- a/.github/workflows/update-cloudflare-proxies.yml
+++ b/.github/workflows/update-cloudflare-proxies.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.ref }}
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
 
       - name: Build to regenerate Cloudflare IPs
         run: dotnet build Common/Common.csproj


### PR DESCRIPTION
Pins all third-party GitHub Actions in workflows and composite actions to immutable commit SHAs, with the resolved tag preserved in a trailing comment.

Generated by `pin_github_actions.py`.