### PR TITLE
chore: stagger dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: tuesday
       time: '06:00'
     groups:
       nuget-dependencies:
@@ -23,7 +23,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: tuesday
       time: '06:00'
     groups:
       github-actions:


### PR DESCRIPTION
Automated by the HeavenVR maintenance bot: moves this repo's dependabot update schedule to Tuesday at 06:00, so PRs land spread across the week instead of every repo in the org opening PRs at the same Monday 06:00 slot.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/Internal.Net/pull/82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->